### PR TITLE
Update Listen.ts with current list of Authentication clusters

### DIFF
--- a/src/Pusher/widget/Listen.ts
+++ b/src/Pusher/widget/Listen.ts
@@ -42,8 +42,8 @@ class NotifyListen extends WidgetBase {
                     this.showError("Authentication key and cluster are required. Please make sure Pusher.Pusher_Key and Pusher.Pusher_Cluster constants are set.");
                     return;
                 }
-                if ([ "eu", "mt1", "us2", "ap1", "ap2" ]. indexOf(keyData.cluster) === -1) {
-                    this.showError(`Authentication cluster "${keyData.cluster}" is not supported. Please make sure  Pusher.Pusher_Cluster constants are set to "eu", "mt1", "us2", "ap1" or "ap2"`);
+                if ([ "mt1", "us2", "us3", "eu", "ap1", "ap2", "ap3", "ap4", "sa1" ]. indexOf(keyData.cluster) === -1) {
+                    this.showError(`Authentication cluster "${keyData.cluster}" is not supported. Please make sure  Pusher.Pusher_Cluster constants are set to "mt1", "us2", "us3", "eu", "ap1", "ap2", "ap3", "ap4" or "sa1");
                     return;
                 }
                 this.pusher = new Pusher(keyData.key, {


### PR DESCRIPTION
Update Listen.ts with current list of Authentication clusters as described in the Pusher documentation: https://pusher.com/docs/channels/miscellaneous/clusters/
> mt1 in N. Virginia
> us2 in Ohio
> us3 in Oregon
> eu in Ireland
> ap1 in Singapore
> ap2 in Mumbai
> ap3 in Tokyo
> ap4 in Sydney
> sa1 in São Paulo